### PR TITLE
添加mknod系统调用以及导出libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ features = ["elf32", "elf64", "endian_fd"]
 
 [target.'cfg(target_os = "dragonos")'.dependencies]
 # Development
-dragonos-dsc = { git = "https://git.mirrors.dragonos.org/DragonOS-Community/dragonos-dsc.git", rev = "ee7a2b9399" }
+dragonos-dsc = { git = "https://git.mirrors.dragonos.org/DragonOS-Community/dragonos-dsc.git", rev = "aa61cb0109" }
 
 [features]
 default = []

--- a/dlibc/Cargo.toml
+++ b/dlibc/Cargo.toml
@@ -46,7 +46,7 @@ features = ["elf32", "elf64", "endian_fd"]
 
 [target.'cfg(target_os = "dragonos")'.dependencies]
 # Development
-dragonos-dsc = { git = "https://git.mirrors.dragonos.org/DragonOS-Community/dragonos-dsc.git", rev = "ee7a2b9399" }
+dragonos-dsc = { git = "https://git.mirrors.dragonos.org/DragonOS-Community/dragonos-dsc.git", rev = "aa61cb0109" }
 
 [features]
 default = ["std"]

--- a/dlibc/src/unix/platform/dragonos/pal/relibc_adapter/pal.rs
+++ b/dlibc/src/unix/platform/dragonos/pal/relibc_adapter/pal.rs
@@ -254,8 +254,8 @@ pub extern "C" fn mkdir(path: *const ::c_char, mode: mode_t) -> ::c_int {
 }
 
 #[no_mangle]
-pub extern "C" fn mkfifo(_path: *const ::c_char, _mode: mode_t) -> ::c_int {
-    unimplemented!()
+pub extern "C" fn mkfifo(path: *const ::c_char, mode: mode_t) -> ::c_int {
+    e(unsafe { syscall!(SYS_MKNOD, path, mode | 4096, 0) }) as ::c_int
 }
 
 #[no_mangle]

--- a/src/start.rs
+++ b/src/start.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec::Vec};
-use core::{fmt::Debug, intrinsics, ptr};
+use core::{intrinsics, ptr};
 use dlibc::unix::platform::allocator::new_mspace;
 use dlibc::{
     ld_so::start::Stack,

--- a/src/std/libc.rs
+++ b/src/std/libc.rs
@@ -1,0 +1,1 @@
+pub use ::dlibc::*;

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -105,6 +105,7 @@ pub mod error;
 pub mod ffi;
 pub mod fs;
 pub mod io;
+pub mod libc;
 pub mod net;
 pub mod num;
 pub mod os;


### PR DESCRIPTION
- 添加mknod系统调用
- 添加libc模块导出dlibc,使得使用drstd的程序也能使用libc的内容进行更底层的编程